### PR TITLE
Add MSYS2 build job to Windows workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -145,15 +145,29 @@ jobs:
           update: true
           install: >-
             base-devel
+            mingw-w64-x86_64-abseil
+            mingw-w64-x86_64-asio
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-fmt
+            mingw-w64-x86_64-nlohmann-json
+            mingw-w64-x86_64-pugixml
+            mingw-w64-x86_64-protobuf
             mingw-w64-x86_64-harfbuzz
             mingw-w64-x86_64-fribidi
             mingw-w64-x86_64-freetype
             mingw-w64-x86_64-openssl
             mingw-w64-x86_64-openal
             mingw-w64-x86_64-glew
+            mingw-w64-x86_64-physfs
+            mingw-w64-x86_64-libogg
+            mingw-w64-x86_64-libvorbis
+            mingw-w64-x86_64-xz
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-luajit
+            mingw-w64-x86_64-gmp
+            mingw-w64-x86_64-pkgconf
 
       - name: Configure (CMake + Ninja, MINGW64)
         run: |


### PR DESCRIPTION
## Summary
- add a new MSYS2-based Windows build alongside the existing MSVC workflow
- configure Ninja-based CMake build using MINGW64 packages and upload artifacts

## Testing
- Not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d3aee8d28832aa119820f38c47e14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated Windows build pipeline for MSYS2/MINGW64 so MinGW-built artifacts are produced and uploaded alongside existing Windows builds; includes CI steps to configure, build, and publish build outputs and capture build logs on failure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->